### PR TITLE
[14.0][IMP] epa_account_payment_order: Lines Payment Bank

### DIFF
--- a/epa_account_payment_order_custom/i18n/pt_BR.po
+++ b/epa_account_payment_order_custom/i18n/pt_BR.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 14.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-09 14:36+0000\n"
-"PO-Revision-Date: 2024-04-09 11:38-0300\n"
+"POT-Creation-Date: 2024-04-09 15:11+0000\n"
+"PO-Revision-Date: 2024-04-09 12:12-0300\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: pt_BR\n"
@@ -31,6 +31,11 @@ msgstr ""
 #: model:ir.model.fields,field_description:epa_account_payment_order_custom.field_account_payment_order____last_update
 msgid "Last Modified on"
 msgstr "Última Modificação em"
+
+#. module: epa_account_payment_order_custom
+#: model:ir.ui.menu,name:epa_account_payment_order_custom.epa_account_payment_line_action
+msgid "Payment Lines"
+msgstr "Linhas de Pagamentos Bancária"
 
 #. module: epa_account_payment_order_custom
 #: model:ir.model,name:epa_account_payment_order_custom.model_account_payment_order

--- a/epa_account_payment_order_custom/views/account_payment_order.xml
+++ b/epa_account_payment_order_custom/views/account_payment_order.xml
@@ -24,4 +24,11 @@
         sequence="2"
     />
 
+    <menuitem
+        id="epa_account_payment_line_action"
+        action="account_payment_order.account_payment_line_action"
+        parent="epa_menu_payment_root"
+        sequence="3"
+    />
+
 </odoo>


### PR DESCRIPTION
cc @marcelsavegnago @WesleyOliveira98 @Matthwhy 

Objetivo dessa PR é incluir o action presente em account.payment.line, na v12 ele estava com um menuitem para visualizar as linhas de pagamentos bancárias, na v14 isso não ocorre, com base nisso o objetivo é adicionar esse action no menu `Payments` criado nesse módulo