### PR TITLE
[14.0][FIX] epa_sale_stock_custom: picking_status computed field

### DIFF
--- a/epa_sale_stock_custom/models/sale_order.py
+++ b/epa_sale_stock_custom/models/sale_order.py
@@ -20,6 +20,7 @@ class SaleOrder(models.Model):
         compute="_compute_picking_status",
         store=True,
         readonly=True,
+        default="no",
     )
 
     @api.depends("state", "picking_ids.state")

--- a/epa_sale_stock_custom/views/sale_order.xml
+++ b/epa_sale_stock_custom/views/sale_order.xml
@@ -66,4 +66,27 @@
         </field>
     </record>
 
+    <record id="ir_cron_recompute_picking_status" model="ir.cron">
+        <field name="name">Recompute Picking Status</field>
+        <field name="model_id" ref="model_sale_order" />
+        <field name="state">code</field>
+        <field
+            name="code"
+        >for order in env["sale.order"].search([]): order._compute_picking_status()</field>
+        <field name="user_id" ref="base.user_root" />
+        <field name="interval_number">1</field>
+        <field name="interval_type">days</field>
+        <field name="numbercall">-1</field>
+        <field name="doall" eval="False" />
+    </record>
+
+    <record id="action_recompute_picking_status" model="ir.actions.server">
+        <field name="name">Recompute Picking Status</field>
+        <field name="model_id" ref="sale.model_sale_order" />
+        <field name="binding_model_id" ref="sale.model_sale_order" />
+        <field name="binding_type">action</field>
+        <field name="state">code</field>
+        <field name="code">for order in records: order._compute_picking_status()</field>
+    </record>
+
 </odoo>


### PR DESCRIPTION
Ticket HT00734

Por algum motivo, o módulo não exibe o valor computado para o campo "Picking Status" em algumas ordens no ambiente do nosso cliente
![image](https://github.com/Escodoo/epa-addons/assets/69807420/3aee7c77-ed87-4e5d-8b64-87c80fb69ba1)

O cliente também relatou casos onde os pickings já haviam sido finalizados e o campo "Picking Status" não atualizou.

Por conta disso, definimos o campo com o valor default `"no"` e criamos uma ação agendada e uma ação no servidor. A Ação Agendada rodará diariamente e atualizará o campo `picking_status` de todas as ordens. E com a Ação do Servidor, será possível a pessoa atualizar esse campo selecionando a ordem e executando essa ação.

cc: @marcelsavegnago @kaynnan @Matthwhy 