### PR TITLE
[14.0][IMP] epa_hr_expense_custom: backport static fields to module

### DIFF
--- a/epa_hr_expense_custom/__manifest__.py
+++ b/epa_hr_expense_custom/__manifest__.py
@@ -11,6 +11,7 @@
     "website": "https://github.com/Escodoo/epa-addons",
     "depends": ["hr_expense"],
     "data": [
+        "views/hr_expense.xml",
         "views/hr_expense_sheet.xml",
     ],
     "demo": [],

--- a/epa_hr_expense_custom/models/hr_expense.py
+++ b/epa_hr_expense_custom/models/hr_expense.py
@@ -2,11 +2,25 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 
-from odoo import models
+from odoo import api, fields, models
 
 
 class HrExpense(models.Model):
     _inherit = "hr.expense"
+
+    fiscal_document_number = fields.Char(
+        string="Fiscal Document",
+        stored=True,
+        copy=True,
+    )
+    fiscal_document_partner_id = fields.Many2one(
+        "res.partner",
+        string="Document Partner",
+        domain=[("company_type", "=", "company")],
+        stored=True,
+        copy=True,
+    )
+    show_fiscal_document = fields.Boolean(compute="_compute_show_fiscal_document")
 
     def _get_account_move_line_values(self):
         move_line_values_by_expense = super()._get_account_move_line_values()
@@ -16,3 +30,8 @@ class HrExpense(models.Model):
                 if "date_maturity" in move_line.keys():
                     move_line["date_maturity"] = expense.sheet_id.maturity_date
         return move_line_values_by_expense
+
+    @api.depends("product_id.categ_id")
+    def _compute_show_fiscal_document(self):
+        for record in self:
+            record.show_fiscal_document = record.product_id.categ_id.id == 31

--- a/epa_hr_expense_custom/views/hr_expense.xml
+++ b/epa_hr_expense_custom/views/hr_expense.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2024 - TODAY, Kaynnan Lemes <kaynnan.lemes@escodoo.com.br>
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+    <record model="ir.ui.view" id="hr_expense_form_view">
+        <field name="name">hr.expense.form (in epa_hr_expense_custom)</field>
+        <field name="model">hr.expense</field>
+        <field name="inherit_id" ref="hr_expense.hr_expense_view_form" />
+        <field name="arch" type="xml">
+            <xpath
+                expr="//field[@name='payment_mode']/ancestor::group"
+                position="after"
+            >
+                <group>
+                    <group>
+                        <field name="show_fiscal_document" invisible="1" />
+                        <field
+                            name="fiscal_document_number"
+                            attrs="{'readonly': [('state', '!=', 'draft')], 'invisible': [('show_fiscal_document', '=', True)]}"
+                        />
+                        <field
+                            name="fiscal_document_partner_id"
+                            attrs="{'readonly': [('state', '!=', 'draft')], 'invisible': [('show_fiscal_document', '=', True)]}"
+                        />
+                    </group>
+                </group>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/epa_hr_expense_custom/views/hr_expense_sheet.xml
+++ b/epa_hr_expense_custom/views/hr_expense_sheet.xml
@@ -16,25 +16,35 @@
                     attrs="{'invisible': [('state', 'not in', ['approve', 'post', 'done'])]}"
                 />
             </field>
+            <xpath expr="//field[@name='expense_line_ids']/tree" position="inside">
+                <field
+                    name="fiscal_document_number"
+                    attrs="{'readonly': [('state', '!=', 'draft')]}"
+                />
+                <field
+                    name="fiscal_document_partner_id"
+                    attrs="{'readonly': [('state', '!=', 'draft')]}"
+                />
+            </xpath>
         </field>
     </record>
 
-<!--    <record model="ir.ui.view" id="hr_expense_sheet_search_view">-->
-<!--        <field name="name">hr.expense.sheet.search (in epa_hr_expense_custom)</field>-->
-<!--        <field name="model">hr.expense.sheet</field>-->
-<!--        <field name="inherit_id" ref="TODO othermodule.search_view" />-->
-<!--        <field name="arch" type="xml">-->
-<!--            &lt;!&ndash; TODO &ndash;&gt;-->
-<!--        </field>-->
-<!--    </record>-->
+    <!--    <record model="ir.ui.view" id="hr_expense_sheet_search_view">-->
+    <!--        <field name="name">hr.expense.sheet.search (in epa_hr_expense_custom)</field>-->
+    <!--        <field name="model">hr.expense.sheet</field>-->
+    <!--        <field name="inherit_id" ref="TODO othermodule.search_view" />-->
+    <!--        <field name="arch" type="xml">-->
+    <!--            &lt;!&ndash; TODO &ndash;&gt;-->
+    <!--        </field>-->
+    <!--    </record>-->
 
-<!--    <record model="ir.ui.view" id="hr_expense_sheet_tree_view">-->
-<!--        <field name="name">hr.expense.sheet.tree (in epa_hr_expense_custom)</field>-->
-<!--        <field name="model">hr.expense.sheet</field>-->
-<!--        <field name="inherit_id" ref="TODO othermodule.tree_view" />-->
-<!--        <field name="arch" type="xml">-->
-<!--            &lt;!&ndash; TODO &ndash;&gt;-->
-<!--        </field>-->
-<!--    </record>-->
+    <!--    <record model="ir.ui.view" id="hr_expense_sheet_tree_view">-->
+    <!--        <field name="name">hr.expense.sheet.tree (in epa_hr_expense_custom)</field>-->
+    <!--        <field name="model">hr.expense.sheet</field>-->
+    <!--        <field name="inherit_id" ref="TODO othermodule.tree_view" />-->
+    <!--        <field name="arch" type="xml">-->
+    <!--            &lt;!&ndash; TODO &ndash;&gt;-->
+    <!--        </field>-->
+    <!--    </record>-->
 
 </odoo>


### PR DESCRIPTION
HT00743

Objetivo: possibilitar edição do campo quando o `state` for igual a `draft`.

Como esse campo foi definido pela interface do Odoo, o que não é uma boa prática, a ideia principal foi realizar o backport considerando as mesmas regras do campo, nome, definidas pela interface para o modelo `hr.expense`.

Temos outro campo que seria necessário trazer para o backport, não sei se vem ao caso, mas estarei colocando a print de como ele foi definido.

![image](https://github.com/user-attachments/assets/81822f79-2582-47be-b616-4013629eaaf0)

cc @WesleyOliveira98 @marcelsavegnago @douglascstd