### PR TITLE
[14.0][IMP] epa_lab_sample_management: block users to change the followers

### DIFF
--- a/epa_lab_sample_management/models/lab_sample.py
+++ b/epa_lab_sample_management/models/lab_sample.py
@@ -204,3 +204,10 @@ class LabSample(models.Model):
             )
         else:
             self.parameter_ids = None
+
+    def message_subscribe(self, partner_ids=None, channel_ids=None):
+        if not self.user_has_groups(
+            "epa_lab_sample_management.group_lab_sample_manager"
+        ):
+            raise ValidationError(_("Just administrators can change the followers."))
+        return super(LabSample, self).message_subscribe(partner_ids, channel_ids)

--- a/epa_lab_sample_management/views/lab_sample.xml
+++ b/epa_lab_sample_management/views/lab_sample.xml
@@ -150,8 +150,8 @@
                     </notebook>
                 </sheet>
                 <div class="oe_chatter">
-                    <field name="message_follower_ids" widget="mail_followers" />
-                    <field name="message_ids" widget="mail_thread" />
+                    <field name="message_follower_ids" />
+                    <field name="message_ids" />
                 </div>
             </form>
         </field>


### PR DESCRIPTION
Ticket: HT00773

Block users to change the sample followers since we have a record rule to only allow the creators or followers of the sample to edit the document. Administrators can edit the followers.

cc: @marcelsavegnago @kaynnan 