### PR TITLE
[14.0][IMP] epa_sale_stock_custom: add search method to picking_status

### DIFF
--- a/epa_sale_stock_custom/models/sale_order.py
+++ b/epa_sale_stock_custom/models/sale_order.py
@@ -16,41 +16,54 @@ class SaleOrder(models.Model):
             ("cancel", "Delivery Cancelled"),
             ("no", "Nothing to Deliver"),
         ],
-        string="Picking Status",
         compute="_compute_picking_status",
-        store=True,
+        search="_search_picking_status",
         readonly=True,
-        default="no",
     )
 
     @api.depends("state", "picking_ids.state")
     def _compute_picking_status(self):
-        """
-        Compute the picking status for the SO. Possible statuses:
-        - no: if the SO is not in status 'sale' nor 'done', we consider that
-          there is nothing to deliver. This is also the default value if the
-          conditions of no other status is met.
-        - cancel: all pickings are cancelled
-        - delivered: if all  pickings are done or cancel.
-        - partially_delivered: If at least one picking is done.
-        - to_deliver: if all pickings are in confirmed, assigned, waiting or
-          cancel state.
-        """
         for order in self:
-            picking_status = "no"
-            if order.state in ("sale", "done") and order.picking_ids:
-                pstates = [picking.state for picking in order.picking_ids]
-                if all([state == "cancel" for state in pstates]):
-                    picking_status = "cancel"
-                elif all([state in ("done", "cancel") for state in pstates]):
-                    picking_status = "delivered"
-                elif any([state == "done" for state in pstates]):
-                    picking_status = "partially_delivered"
-                elif all(
-                    [
-                        state in ("confirmed", "assigned", "waiting", "cancel")
-                        for state in pstates
-                    ]
-                ):
-                    picking_status = "to_deliver"
-            order.picking_status = picking_status
+            order.picking_status = order._get_picking_status()
+
+    def _get_picking_status(self):
+        self.ensure_one()
+        picking_status = "no"
+        if self.state in ("sale", "done") and self.picking_ids:
+            pstates = self.picking_ids.mapped("state")
+            if all([state == "cancel" for state in pstates]):
+                picking_status = "cancel"
+            elif all([state in ("done", "cancel") for state in pstates]):
+                picking_status = "delivered"
+            elif any([state == "done" for state in pstates]):
+                picking_status = "partially_delivered"
+            elif all(
+                [
+                    state in ("confirmed", "assigned", "waiting", "cancel")
+                    for state in pstates
+                ]
+            ):
+                picking_status = "to_deliver"
+        return picking_status
+
+    @api.model
+    def _search_picking_status(self, operator, value):
+        orders = self.search(
+            [
+                ("state", "in", ("sale", "done")),
+                ("picking_ids", "!=", False),
+            ]
+        )
+
+        if operator == "=":
+            orders = orders.filtered(lambda o: o._get_picking_status() == value)
+        elif operator == "!=":
+            orders = orders.filtered(lambda o: o._get_picking_status() != value)
+        elif operator == "in":
+            orders = orders.filtered(lambda o: o._get_picking_status() in value)
+        elif operator == "not in":
+            orders = orders.filtered(lambda o: o._get_picking_status() not in value)
+        else:
+            raise ValueError("Unsupported operator %s" % operator)
+
+        return [("id", "in", orders.ids)]

--- a/epa_sale_stock_custom/views/sale_order.xml
+++ b/epa_sale_stock_custom/views/sale_order.xml
@@ -66,27 +66,4 @@
         </field>
     </record>
 
-    <record id="ir_cron_recompute_picking_status" model="ir.cron">
-        <field name="name">Recompute Picking Status</field>
-        <field name="model_id" ref="model_sale_order" />
-        <field name="state">code</field>
-        <field
-            name="code"
-        >for order in env["sale.order"].search([]): order._compute_picking_status()</field>
-        <field name="user_id" ref="base.user_root" />
-        <field name="interval_number">1</field>
-        <field name="interval_type">days</field>
-        <field name="numbercall">-1</field>
-        <field name="doall" eval="False" />
-    </record>
-
-    <record id="action_recompute_picking_status" model="ir.actions.server">
-        <field name="name">Recompute Picking Status</field>
-        <field name="model_id" ref="sale.model_sale_order" />
-        <field name="binding_model_id" ref="sale.model_sale_order" />
-        <field name="binding_type">action</field>
-        <field name="state">code</field>
-        <field name="code">for order in records: order._compute_picking_status()</field>
-    </record>
-
 </odoo>


### PR DESCRIPTION
@Escodoo HT01321

Removendo as ações que estava resetando o tier validation, o problema é que o campo `picking_status` precisa ser stored para funcionar nos filtros, e para atualizar essa campo eu tinha criado essas ações, estou adicionando o campo `picking_count` que fará o compute sem store e chamando o método `_compute_picking_status` mantendo o campo `picking_status` atualizado sempre que o registro (`sale.order`) for lido.

cc: @marcelsavegnago @kaynnan @CristianoMafraJunior